### PR TITLE
Add basic Doxygen config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+Coding Conventions
+------------------
+- All modified files must use modern idiomatic style and be fully commented for Doxygen.
+- Decompose, unroll, flatten, and factor logic where practical during edits.
+- Document purpose, parameters, returns, and globals for each function using `///` or `/** */`.
+- Ensure build scripts list dependencies for Doxygen, Sphinx, Breathe, CLOC, qemu, and tmux.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ the same version. See the
 [build instructions](https://omnios.org/dev/build_instructions) for further
 information.
 
+For documentation builds, run `./rootsetup` to install additional tooling such
+as Doxygen and Sphinx.
+
 ## Contributing
 
 The OmniOS fork is regularly updated with changes from the upstream

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,0 +1,7 @@
+# Minimal Doxygen configuration
+PROJECT_NAME = "Illumos"
+OUTPUT_DIRECTORY = docs/doxygen
+RECURSIVE = YES
+INPUT = ..
+GENERATE_HTML = YES
+GENERATE_LATEX = NO

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This repository uses Doxygen to generate API references and Sphinx for prose documentation. Run the following after installing the dependencies listed in `rootsetup`:
+
+```sh
+doxygen docs/Doxyfile
+```
+
+Sphinx integration is expected via the Breathe extension once available.

--- a/rootsetup
+++ b/rootsetup
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+# Install build dependencies
+sudo apt-get update -y
+sudo apt-get install -y doxygen python3-sphinx python3-breathe cloc qemu-system-x86 qemu-utils qemu-system-x86 qemu-nox tmux

--- a/usr/src/boot/libsa/string/bzero.c
+++ b/usr/src/boot/libsa/string/bzero.c
@@ -1,5 +1,10 @@
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
+/**
+ * @file bzero.c
+ * @brief Thin wrapper to build bzero using the memset implementation.
+ */
 #define	BZERO
+// Build bzero from the shared memset implementation.
 #include "memset.c"

--- a/usr/src/boot/libsa/string/memset.c
+++ b/usr/src/boot/libsa/string/memset.c
@@ -38,6 +38,15 @@ __FBSDID("$FreeBSD$");
 
 #include <sys/types.h>
 
+/**
+ * @file memset.c
+ * @brief Shared implementation for memset and bzero.
+ *
+ * The file is included with different macros defined so that the same
+ * code can implement both functions. When compiled with @c BZERO defined
+ * the resulting function is @c bzero; otherwise it provides @c memset.
+ */
+
 #include <limits.h>
 
 #define	wsize	sizeof(u_int)
@@ -50,8 +59,13 @@ __FBSDID("$FreeBSD$");
 #define	VAL	0
 #define	WIDEVAL	0
 
-void
-bzero(void *dst0, size_t length)
+/**
+ * Fill a region of memory with zeros.
+ *
+ * @param dst0   destination memory pointer
+ * @param length number of bytes to clear
+ */
+void bzero(void *dst0, size_t length)
 #else
 #include <string.h>
 
@@ -59,8 +73,16 @@ bzero(void *dst0, size_t length)
 #define	VAL	c0
 #define	WIDEVAL	c
 
-void *
-memset(void *dst0, int c0, size_t length)
+/**
+ * Set each byte of a memory region to a given value.
+ *
+ * @param dst0   destination memory pointer
+ * @param c0     value to set each byte to
+ * @param length number of bytes to modify
+ *
+ * @return pointer to @p dst0
+ */
+void *memset(void *dst0, int c0, size_t length)
 #endif
 {
 	size_t t;


### PR DESCRIPTION
## Summary
- set contribution policy in `AGENTS.md`
- provide a minimal Doxygen configuration and docs outline
- document build steps for docs in `README.md`
- add helper `rootsetup` script
- comment `bzero.c` and `memset.c`

## Testing
- `doxygen docs/Doxyfile` *(fails: command not found)*
- `cloc .` *(fails: command not found)*
- `gmake -n` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68462da03ce483319113a9e8b22fc477

## Summary by Sourcery

Set up a basic Doxygen-based documentation pipeline by adding configuration files, coding conventions, helper scripts, and inline comments for existing string functions

New Features:
- Provide a minimal Doxygen configuration and outline for generating API reference
- Add AGENTS.md with coding conventions and Doxygen documentation policy

Enhancements:
- Add rootsetup script to install Doxygen, Sphinx, and other documentation tooling
- Annotate memset.c and bzero.c implementations with Doxygen-compliant comments

Documentation:
- Update README.md with documentation build instructions
- Add docs/README.md guide for building and integrating API docs