### PR TITLE
Enable strict Doxygen warnings

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -5,4 +5,9 @@ RECURSIVE = YES
 INPUT = usr/src/psm/promif/ieee1275
 GENERATE_HTML = YES
 GENERATE_LATEX = NO
+# Produce XML for Breathe/Sphinx integration
 GENERATE_XML = YES
+
+# Warn for undocumented entities and fail on warnings
+WARN_IF_UNDOCUMENTED = YES
+WARN_AS_ERROR = YES


### PR DESCRIPTION
## Summary
- generate Doxygen XML for Breathe
- fail when documentation is missing

## Testing
- `doxygen docs/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_6846489974f48331a44346a79d9ae947