### PR TITLE
Add doc check script and integrate cloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /.vscode
 # BEGIN AUTO-GENERATED
 tools/
+!tools/check_docs.sh
 usr/src/cmd/bhhwcompat/bhhwcompat
 usr/src/cmd/cdpadm/cdpadm
 usr/src/cmd/cmd-inet/usr.lib/in.cdpd/in.cdpd

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ the same version. See the
 information.
 
 For documentation builds, run `./rootsetup` to install additional tooling such
-as Doxygen and Sphinx.
+as Doxygen and Sphinx. Continuous integration environments can invoke
+`tools/check_docs.sh` to generate documentation and report warnings.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,13 @@ This repository uses Doxygen to generate API references and Sphinx for prose doc
 doxygen docs/Doxyfile
 ```
 
+The repository also provides a helper script that runs Doxygen and
+reports any warnings while quantifying documentation coverage. Execute:
+
+```sh
+tools/check_docs.sh
+```
+
 After Doxygen generates XML output, build the Sphinx documentation:
 
 ```sh

--- a/tools/check_docs.sh
+++ b/tools/check_docs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+##
+# @file check_docs.sh
+# @brief Generate documentation and measure coverage.
+#
+# This script runs Doxygen using the docs/Doxyfile configuration and
+# captures all warnings emitted during the run. It also executes cloc to
+# report on the amount of source code compared to documentation.
+#
+# Usage:
+#   tools/check_docs.sh
+##
+
+set -euo pipefail
+
+# Resolve repository root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DOXYFILE="$REPO_ROOT/docs/Doxyfile"
+DOXY_DIR="$REPO_ROOT/docs/doxygen"
+DOXY_WARN="$DOXY_DIR/warnings.log"
+CLOC_REPORT="$DOXY_DIR/cloc_report.txt"
+
+mkdir -p "$DOXY_DIR"
+
+# Generate documentation and capture warnings
+if doxygen "$DOXYFILE" 2>"$DOXY_WARN"; then
+	echo "Doxygen run completed." >&2
+else
+	echo "Doxygen exited with errors." >&2
+fi
+
+# Summarize warnings
+WARNINGS=$(grep -ci "warning" "$DOXY_WARN" || true)
+if [ "$WARNINGS" -gt 0 ]; then
+	echo "Found $WARNINGS Doxygen warnings:" >&2
+	cat "$DOXY_WARN"
+else
+	echo "No Doxygen warnings." >&2
+fi
+
+# Measure code and documentation lines
+cloc "$REPO_ROOT/usr/src" "$REPO_ROOT/docs" --quiet --csv --out "$CLOC_REPORT"
+
+echo "Documentation coverage report:" >&2
+cat "$CLOC_REPORT"


### PR DESCRIPTION
## Summary
- implement `tools/check_docs.sh` for doxygen validation and cloc coverage
- link the new script from the documentation and README
- adjust `.gitignore` to allow the script

## Testing
- `tools/check_docs.sh >/tmp/check_docs.log 2>&1 && tail -n 20 /tmp/check_docs.log`

------
https://chatgpt.com/codex/tasks/task_e_684648a5fe3c8331b8bde60bd1fba27c