### PR TITLE
Improve doc build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ the same version. See the
 [build instructions](https://omnios.org/dev/build_instructions) for further
 information.
 
-For documentation builds, run `./rootsetup` to install additional tooling such
-as Doxygen and Sphinx.
+For documentation builds, run `./rootsetup` to install the tools required for
+generating the manual. This script adds Doxygen, Sphinx, the Breathe
+extension, CLOC, qemu, and tmux. Once installed, create the Doxygen XML by
+running `doxygen docs/Doxyfile` and then invoke `sphinx-build docs/sphinx
+docs/html` to generate the HTML output. If a `docs/Makefile` is added, you can
+simply run `make html` in that directory instead.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document Doxygen & Sphinx workflow in the README

## Testing
- `./rootsetup` *(fails: debconf warnings)*
- `doxygen docs/Doxyfile`
- `sphinx-build docs/sphinx docs/html`


------
https://chatgpt.com/codex/tasks/task_e_684648936998833194cc5dabaf99825f