### PR TITLE
Add Sphinx build docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,18 @@
 # Documentation
 
-This repository uses Doxygen to generate API references and Sphinx for prose documentation. Run the following after installing the dependencies listed in `rootsetup`:
+This repository uses Doxygen to build API references and Sphinx for prose manuals.
+After installing the dependencies listed in `rootsetup`, generate the XML output:
 
 ```sh
 doxygen docs/Doxyfile
 ```
 
-After Doxygen generates XML output, build the Sphinx documentation:
+Once Doxygen completes, build the HTML documentation via Sphinx:
 
 ```sh
 cd docs/sphinx
 make html
 ```
 
-The configuration in `docs/sphinx/conf.py` integrates the Breathe extension
-and targets the Read the Docs theme for a uniform appearance.
+The configuration in `docs/sphinx/conf.py` integrates the Breathe extension and
+selects the Read the Docs theme for a uniform appearance.

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,8 +1,32 @@
-import os
-import sys
+"""Sphinx configuration for Illumos documentation.
 
-project = 'Illumos'
-extensions = ['breathe']
-breathe_projects = {'Illumos': os.path.join(os.path.dirname(__file__), '..', 'doxygen', 'xml')}
-breathe_default_project = 'Illumos'
-html_theme = 'sphinx_rtd_theme'
+This setup reads the XML produced by Doxygen through the Breathe extension
+and renders HTML using the Read the Docs theme.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+
+def _breathe_xml_dir() -> str:
+    """Return the absolute path to the Doxygen XML directory.
+
+    Returns:
+        str: Path to ``doxygen/xml`` within the repository.
+    """
+    return str(pathlib.Path(__file__).resolve().parent.parent / "doxygen" / "xml")
+
+
+# Basic project information
+project = "Illumos"
+
+# Extensions to load by Sphinx
+extensions = ["breathe"]
+
+# Breathe configuration
+breathe_projects = {"Illumos": _breathe_xml_dir()}
+breathe_default_project = "Illumos"
+
+# HTML theme configuration
+html_theme = "sphinx_rtd_theme"

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,7 +1,5 @@
 Illumos Documentation
 =====================
 
-.. toctree::
-   :maxdepth: 2
-
-   api
+.. doxygenindex::
+   :project: Illumos


### PR DESCRIPTION
## Summary
- clarify how to build Sphinx documentation
- integrate Breathe with Doxygen output

## Testing
- `doxygen docs/Doxyfile` *(fails: command not found)*
- `make -C docs/sphinx html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464876e4948331807871fc5f48e521